### PR TITLE
[test] increase timeout of waiting for streamer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,8 @@ Current head v.2.1.0 rc
   * Added license and readme to externals (#18)
 - CI
   * Add github ci with build and install (#22)
+- Tests
+  * Fix timeout error on macos (#33)
 
 ---
 v.2.0.0

--- a/src/server/impl2/ViewerClient2.cpp
+++ b/src/server/impl2/ViewerClient2.cpp
@@ -105,7 +105,8 @@ void ViewerClient2::notifyNewStreamer( const StreamerClient2* streamer ) {
     // This is why we don't wait for the deadly client at the end of this method.
     // The reason for waiting for the client to connect is that after the end of this function, if the client is not available and functions are called immediately after notification, some tests will not pass.
     // Fix : use a better way of doing things
-    while ( iTry < 10 && !m_clientStreamAdded ) {
+    while ( iTry < 20 && !m_clientStreamAdded ) // timeout: 200 ms
+    {
         std::cout << "[ViewerClient] waiting for streamer added ..." << std::endl;
         std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
         ++iTry;


### PR DESCRIPTION
Some tests failed on previous pull request #31 on main.
Increase timeout of waiting for streamer for github macos runner slower than gitlab macos runner.
